### PR TITLE
Remove computation of "nave" to avoid division by zero

### DIFF
--- a/sorc/prepobs_prepacqc.fd/acftobs_qc.f
+++ b/sorc/prepobs_prepacqc.fd/acftobs_qc.f
@@ -9620,10 +9620,10 @@ c-----------------------------------
 c
 c Output basic stats
 c ------------------
-      nave = (numreps-nmiss) / (kflight-1)
+c      nave = (numreps-nmiss) / (kflight-1)
       write(io8,*)
       write(io8,*) kflight,' different flights found'
-      write(io8,*) nave,' reports per flight, on average'
+c      write(io8,*) nave,' reports per flight, on average'
 c
 c Output indices for each flight
 c ------------------------------


### PR DESCRIPTION
'nave' is a non-essential variable, but computing it leads to division by zero on a very rare occasion (see sorc/prepobs_prepacqc.fd/acftobs_qc.f)
nave = (numreps-nmiss) / (kflight-1)

Comment out the computing and print out lines.