### PR TITLE
Comment compute/print of "nave" as nonessential that causes division by zero

### DIFF
--- a/sorc/prepobs_prepacqc.fd/acftobs_qc.f
+++ b/sorc/prepobs_prepacqc.fd/acftobs_qc.f
@@ -9620,10 +9620,10 @@ c-----------------------------------
 c
 c Output basic stats
 c ------------------
-      nave = (numreps-nmiss) / (kflight-1)
+c      nave = (numreps-nmiss) / (kflight-1)
       write(io8,*)
       write(io8,*) kflight,' different flights found'
-      write(io8,*) nave,' reports per flight, on average'
+c      write(io8,*) nave,' reports per flight, on average'
 c
 c Output indices for each flight
 c ------------------------------


### PR DESCRIPTION
Comment the lines to compute/print "nave" as it's a nonessential variable which on a rare occasion may cause division by zero (when only one flight is present).

The code change is tested with empty dump files (aircar and aircft) to simulate missing data.

[dlogin07 /lfs/h2/emc/stmp/Iliana.Genkova]$ binv  CRON/DIV0/com/obsproc/v1.0.0/gfs.20220318/00/atmos/gfs.t00z.prepbufr
type        messages       subsets         bytes
ADPUPA           397          1249       3226898        3.15
**AIRCAR          2939        274050      29209620       93.25
AIRCFT           383         37542       3799222       98.02**
SATWND          1543        206343      15352704      133.73
VADWND             2            48         17008       24.00
ADPSFC          1458        155280      14475318      106.50
SFCSHP           413         53465       4097098      129.46
GPSIPW             6           760         41364      126.67
RASSDA            14           201        113138       14.36
ASCATW           738        119160       7308612      161.46
TOTAL           7893        848098      77640982
 
[dlogin07 /lfs/h2/emc/stmp/Iliana.Genkova]$ binv CRON/DIV0/com/obsproc/v1.0.0/gfs.20220318/00/atmos/gfs.t00z.prepbufr.**tank0**
type        messages       subsets         bytes
ADPUPA           397          1249       3226898        3.15
SATWND          1543        206343      15352704      133.73
VADWND             2            48         17008       24.00
ADPSFC          1458        155280      14475318      106.50
SFCSHP           413         53465       4097098      129.46
GPSIPW             6           760         41364      126.67
RASSDA            14           201        113138       14.36
ASCATW           738        119160       7308612      161.46
TOTAL           4571        536506      44632140 

Corresponding log files (/lfs/h2/emc/stmp/Iliana.Genkova):
obsproc_gfs_prep_20220318_00_DIV0.o4563356
obsproc_gfs_prep_20220318_00_DIV0.o4562409.tank0