### PR TITLE
Add non-mpiexec support when BACK=YES in prepobs_makeprepbufr.sh

### DIFF
--- a/ush/prepobs_makeprepbufr.sh
+++ b/ush/prepobs_makeprepbufr.sh
@@ -2177,7 +2177,11 @@ set -x
          fi
       elif [ $BACK = 'YES' ] ; then
          echo 'BACK=YES'		 
-	 mpiexec -np 6 --cpu-bind verbose,core $DATA/prepthrds.sh # Keep '-np 6' > NSPLIT=4
+         if [ "$launcher_PREP" = mpiexec ]; then
+	   mpiexec -np 6 --cpu-bind verbose,core $DATA/prepthrds.sh # Keep '-np 6' > NSPLIT=4
+         else
+           $DATA/prepthrds.sh
+         fi
       fi
       totalt=$NSPLIT
    else


### PR DESCRIPTION
This PR adds back in `BACK=YES` functionality that existed in previous versions of `prepobs_makeprepbufr.sh` and was utilized by the GFS prep jobs within developer GFS runs outside of operations. The current `BACK=YES` block in `prepobs_makeprepbufr.sh` only supports the `mpiexec` launcher, which is for the PBSpro scheduler on WCOSS2. The other supported non-WCOSS2 NOAA platforms use `mpirun` (LSF, WCOSS-Dells, going away soon) or `srun` (SLURM, Hera/Orion/Jet). The `BACK=YES` option used in previous GFS prep jobs runs a simple non-launcher command of `$DATA/prepthrds.sh`. The `POE=YES` (alternate to `BACK=YES`) block is still being worked on for similar updates to support SLURM/srun. There will be a separate PR for updating the `POE=YES` block (technically the `POE!=NO` block).

The `mpiexec` line in `prepobs_makeprepbufr.sh` is changed from this:
```
mpiexec -np 6 --cpu-bind verbose,core $DATA/prepthrds.sh # Keep '-np 6' > NSPLIT=4
```
...to this:
```
if [ "$launcher_PREP" = mpiexec ]; then
  mpiexec -np 6 --cpu-bind verbose,core $DATA/prepthrds.sh # Keep '-np 6' > NSPLIT=4
else
  $DATA/prepthrds.sh
fi
```

The changes are:
1. added check for `launcher_PREP = mpiexec` to retain WCOSS2/ops functionality:
```
Kate.Friedman@clogin04> grep launcher_PREP= /lfs/h1/ops/prod/output/20220502/obsproc_gdas_atmos_prep_00.o2748797
+ 0.066s + launcher_PREP=mpiexec
```

2. added `else` when `launcher_PREP != mpiexec`:
```
Orion-login-3[82] /work/noaa/stmp/kfriedma/comrot/devv16_384$ grep launcher_PREP= logs/2022010900/gdasprep.log
+ launcher_PREP=srun
launcher_PREP=srun
```

`launcher_PREP=srun` is set in the GFS `env/ORION.env`, will be set similarly in `env/HERA.env`, and will be `launcher_PREP=mpiexec` in `env/WCOSS2.env`. This `launcher_PREP` setting could also be used by other applications beyond the GFS.

This was tested successfully on Orion and WCOSS2.

Refs: #6 