### PR TITLE
Add Jet build support to prepobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Move into desired branch and then run:
 INSTALL_PREFIX=/path/you/wish/to/install/prepobs ./build.sh
 ```
 
-build.sh default to building for WCOSS2, but it also supports Hera and Orion by setting `INSTALL_TARGET=hera/orion/wcoss2`
+build.sh default to building for WCOSS2, but it also supports Hera, Jet, and Orion by setting `INSTALL_TARGET=hera/jet/orion/wcoss2`
 
 or install in local clone space:
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"$pkg_root/install"}
 MODULEFILE_INSTALL_PREFIX=${MODULEFILE_INSTALL_PREFIX:-"${INSTALL_PREFIX}/modulefiles"}
 
 target=$(echo $INSTALL_TARGET | tr [:upper:] [:lower:])
-if [[ "$target" =~ ^(wcoss2|hera|orion)$ ]]; then
+if [[ "$target" =~ ^(wcoss2|hera|orion|jet)$ ]]; then
   source $pkg_root/versions/build.ver
   set +x
   module purge

--- a/modulefiles/prepobs_jet.lua
+++ b/modulefiles/prepobs_jet.lua
@@ -1,0 +1,15 @@
+help([[
+Load environment to build prepobs on Jet
+]])
+
+load("cmake/3.20.1")
+
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack")
+load("hpc/1.2.0")
+load("hpc-intel/18.0.5.274")
+load("hpc-impi/2018.4.274")
+
+-- Load common modules for this package
+load("prepobs_common")
+
+whatis("Description: prepobs build environment")


### PR DESCRIPTION
This PR adds build support for RDHPCS Jet in prepobs.

Changes:

- Add reference to Jet in `README.md`
- Add "jet" to target list in `build.sh`
- Create module file (`modulefiles/prepobs_jet.lua`) for Jet.

Closes #15 