### PR TITLE
Generalize getges_driver COM lookback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Move into desired branch and then run:
 INSTALL_PREFIX=/path/you/wish/to/install/prepobs ./build.sh
 ```
 
-build.sh default to building for WCOSS2, but it also supports Hera and Orion by setting `INSTALL_TARGET=hera/orion/wcoss2`
+build.sh default to building for WCOSS2, but it also supports Hera, Jet, and Orion by setting `INSTALL_TARGET=hera/jet/orion/wcoss2`
 
 or install in local clone space:
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"$pkg_root/install"}
 MODULEFILE_INSTALL_PREFIX=${MODULEFILE_INSTALL_PREFIX:-"${INSTALL_PREFIX}/modulefiles"}
 
 target=$(echo $INSTALL_TARGET | tr [:upper:] [:lower:])
-if [[ "$target" =~ ^(wcoss2|hera|orion)$ ]]; then
+if [[ "$target" =~ ^(wcoss2|hera|orion|jet)$ ]]; then
   source $pkg_root/versions/build.ver
   set +x
   module purge

--- a/modulefiles/prepobs_jet.lua
+++ b/modulefiles/prepobs_jet.lua
@@ -1,0 +1,15 @@
+help([[
+Load environment to build prepobs on Jet
+]])
+
+load("cmake/3.20.1")
+
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack")
+load("hpc/1.2.0")
+load("hpc-intel/18.0.5.274")
+load("hpc-impi/2018.4.274")
+
+-- Load common modules for this package
+load("prepobs_common")
+
+whatis("Description: prepobs build environment")

--- a/ush/getges_driver.sh
+++ b/ush/getges_driver.sh
@@ -189,9 +189,7 @@ fi
 #######################################################################################################
 elif [[ `echo $bn_COMINgdas | cut -c1` != g && `echo $bn_COMINgfs | cut -c1` != g ]];then
 
-# This runs the GFSv15 version with cycle time directory in the suffix of $COMINgdas and $COMINgfs
-# -or-
-# This runs the GFSv16+ version with cycle time and atmos directory in the suffix of 
+# This runs GFS v15+ by replacing ${PDY}/${cyc} with new values.
 # $COMINGgdas and $COMINgfs
 
 
@@ -200,15 +198,8 @@ elif [[ `echo $bn_COMINgdas | cut -c1` != g && `echo $bn_COMINgfs | cut -c1` != 
 #  rinse and repeat until you've gone back 24 hours - if still no luck give up
 # ------------------------------------------------------------------------------------
 
-COMINgdas_root=`dirname $COMINgdas`
-COMINgdas_root=`dirname $COMINgdas_root`
-COMINgfs_root=`dirname $COMINgfs`
-COMINgfs_root=`dirname $COMINgfs_root`
-if [[ `echo $bn_COMINgdas | cut -c1` = a && `echo $bn_COMINgfs | cut -c1` = a ]];then
-   # if atmos suffix, run dirname additional time
-   COMINgdas_root=`dirname $COMINgdas_root`
-   COMINgfs_root=`dirname $COMINgfs_root`
-fi
+COMINgdas_orig="${COMINgdas}"
+COMINgfs_orig="${COMINgfs}"
 
 PDY_this_try=$PDY
 cyc_this_try=$cyc
@@ -219,14 +210,8 @@ modhr=`expr $cyc_this_try % 6`
 PDY_this_try=`$NDATE -$modhr ${PDY_this_try}${cyc_this_try} | cut -c1-8`
 cyc_this_try=`$NDATE -$modhr ${PDY_this_try}${cyc_this_try} | cut -c9-10`
 
-if [[ `echo $bn_COMINgdas | cut -c1` = a && `echo $bn_COMINgfs | cut -c1` = a ]];then
-   # if atmos suffix, define $COMINgdas and $COMINgfs accordingly 
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-else
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}
-fi
+COMINgdas=${COMINgdas_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
+COMINgfs=${COMINgfs_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
 fhend=12
 
 if [ $fhr = "-3" -o $fhr = "+3" ]; then
@@ -258,14 +243,8 @@ fi
 PDY_this_try=`$NDATE -6 ${PDY_this_try}${cyc_this_try} | cut -c1-8`
 cyc_this_try=`$NDATE -6 ${PDY_this_try}${cyc_this_try} | cut -c9-10`
 
-if [[ `echo $bn_COMINgdas | cut -c1` = a && `echo $bn_COMINgfs | cut -c1` = a ]];then
-   # if atmos suffix, define $COMINgdas and $COMINgfs accordingly 
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-else
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}
-fi
+COMINgdas=${COMINgdas_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
+COMINgfs=${COMINgfs_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
 fhend=12
 
 if [ $fhr = "-3" -o $fhr = "+3" ]; then
@@ -297,14 +276,8 @@ fi
 PDY_this_try=`$NDATE -6 ${PDY_this_try}${cyc_this_try} | cut -c1-8`
 cyc_this_try=`$NDATE -6 ${PDY_this_try}${cyc_this_try} | cut -c9-10`
 
-if [[ `echo $bn_COMINgdas | cut -c1` = a && `echo $bn_COMINgfs | cut -c1` = a ]];then
-   # if atmos suffix, define $COMINgdas and $COMINgfs accordingly 
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-else
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}
-fi
+COMINgdas=${COMINgdas_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
+COMINgfs=${COMINgfs_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
 fhend=18
 
 if [ $fhr = "-3" -o $fhr = "+3" ]; then
@@ -336,14 +309,8 @@ fi
 PDY_this_try=`$NDATE -6 ${PDY_this_try}${cyc_this_try} | cut -c1-8`
 cyc_this_try=`$NDATE -6 ${PDY_this_try}${cyc_this_try} | cut -c9-10`
 
-if [[ `echo $bn_COMINgdas | cut -c1` = a && `echo $bn_COMINgfs | cut -c1` = a ]];then
-   # if atmos suffix, define $COMINgdas and $COMINgfs accordingly 
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}/${COMPONENT}
-else
-   export COMINgdas=$COMINgdas_root/gdas.${PDY_this_try}/${cyc_this_try}
-   export COMINgfs=$COMINgfs_root/gfs.${PDY_this_try}/${cyc_this_try}
-fi
+COMINgdas=${COMINgdas_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
+COMINgfs=${COMINgfs_orig/${PDY}\/${cyc}/${PDY_this_try}/${cyc_this_try}}
 fhend=384
 
 if [ $fhr = "-3" -o $fhr = "+3" ]; then


### PR DESCRIPTION
The upcoming update to GFS v17 will substantially change the COM paths for the GFS package. This requires updates to the lookback capability of getges_driver where it checks previous cycles. Rather than add additional logical branches to handle new COM patterns, the process is generalized by instead doing a string substitution to replace the current day and cycle with those for the prior cycle. This method is backwards compatible and should work for any path as long as it contains `${PDY}/${cyc}`.

Additional changes will likely be needed for GFSv17 to run prepobs stand- alone (as in ops) to match the new `$COMINgdas` and `$COMINgfs`, but these changes work when running prepobs as part of global workflow in development.

Also, I have not otherwise modified the existing style of the scripts, redefining `$COMINgdas` and `$COMINgfs`. However, this will need to be changed before GFSv17 to stop overwriting these variables to meet NCO requirements (see NOAA-EMC/global-workflow#293).

Refs: #17
Refs: NOAA-EMC/global-workflow#761