### PR TITLE
Update prepobs_orion.lua to fix MODULEPATH

### DIFF
--- a/modulefiles/prepobs_orion.lua
+++ b/modulefiles/prepobs_orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build prepobs on Orion
 ]])
 
-prepend_path("MODULEPATH", pathJoin("/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-" .. (os.getenv("spack_stack_ver") or "None"), "/envs/" .. (os.getenv("spack_env") or "None"), "-env-rocky9/install/modulefiles/Core"))
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/gsi-addon-env-rocky9/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
 stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"


### PR DESCRIPTION
Remove variable grabs from environment and hardcode spack version and spack env in `MODULEPATH` for Orion. Will test variable use again in future prepobs update.

Refs #29