### PR TITLE
Add/update files to build and run prepobs on Gaea C5

### DIFF
--- a/modulefiles/prepobs_gaea.lua
+++ b/modulefiles/prepobs_gaea.lua
@@ -1,0 +1,18 @@
+help([[
+Load environment to build prepobs on Gaea
+]])
+
+prepend_path("MODULEPATH", os.getenv("spack_stack_mod_path"))
+
+stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
+stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
+cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("cmake", cmake_ver))
+
+-- Load common modules for this package
+load("prepobs_common")
+
+whatis("Description: prepobs build environment")

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -10,7 +10,7 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"${pkg_root}/install"}
 MODULEFILE_INSTALL_PREFIX=${MODULEFILE_INSTALL_PREFIX:-"${INSTALL_PREFIX}/modulefiles"}
 
 target="${INSTALL_TARGET,,}"
-if [[ "${target}" =~ ^(wcoss2|hera|orion|jet|hercules)$ ]]; then
+if [[ "${target}" =~ ^(wcoss2|hera|orion|jet|hercules|gaea)$ ]]; then
   # prepare the target specific build.ver and run.ver
   cd "${pkg_root}/versions" || exit 1
   rm -f build.ver run.ver

--- a/versions/build.gaea.ver
+++ b/versions/build.gaea.ver
@@ -1,0 +1,4 @@
+export stack_intel_ver=2023.1.0
+export stack_cray_mpich_ver=8.1.25
+source "${HOMEprepobs:-}/versions/spack.ver"
+export spack_stack_mod_path="/ncrc/proj/epic/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}-dev/install/modulefiles/Core"

--- a/versions/run.gaea.ver
+++ b/versions/run.gaea.ver
@@ -1,0 +1,4 @@
+export stack_intel_ver=2023.1.0
+export stack_cray_mpich_ver=8.1.25
+source "${HOMEprepobs:-}/versions/spack.ver"
+export spack_stack_mod_path="/ncrc/proj/epic/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}-dev/install/modulefiles/Core"


### PR DESCRIPTION
Added modulefiles/prepobs_gaea.lua to build prepobs on Gaea-C5.  Spack-stack gsi-addon-dev environment used for bufr/11.7.0.
Tested with C96_atm3DVar.yaml experiment from the global-workflow CI tests.

Refs #32 
Refs NOAA-EMC/global-workflow [#2766](https://github.com/NOAA-EMC/global-workflow/issues/2766)

I'm starting this PR in draft mode. Gaea-C5 will only be supporting a legacy ksh version, which does not support regex expressions (extended globbing is supported instead.)  For this reason, `prepobs/v1.0.2/install/ush/prepobs_makeprepbufr.sh` silently fails with `[1620]: syntax error: unexpected operator/operand '=~'` on this line: `if [[ "$COMSP" =~ (^/com/|^/com2/|^/gpfs/.../nco/ops/com/)`.  The C96_atm3DVar workflow still completes successfully.  I'm tracking a ticket with Gaea SA, and hopefully will resolve this set back soon. 