### PR TITLE
Update to spack-stack/1.9.2

### DIFF
--- a/modulefiles/prepobs_gaeac6.lua
+++ b/modulefiles/prepobs_gaeac6.lua
@@ -15,4 +15,6 @@ load(pathJoin("cmake", cmake_ver))
 -- Load common modules for this package
 load("prepobs_common")
 
+unload("cray-libsci")
+
 whatis("Description: prepobs build environment")

--- a/versions/build.hera.ver
+++ b/versions/build.hera.ver
@@ -1,3 +1,4 @@
+export spack_stack_ver=1.9.1
 export stack_oneapi_ver=2024.2.1
 export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"

--- a/versions/build.hera.ver
+++ b/versions/build.hera.ver
@@ -1,6 +1,6 @@
-export spack_stack_ver=1.9.1
 export stack_oneapi_ver=2024.2.1
 export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"
+export spack_stack_ver=1.9.1
 export cmake_ver=3.27.9
 export spack_stack_mod_path="/contrib/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"

--- a/versions/run.hera.ver
+++ b/versions/run.hera.ver
@@ -1,3 +1,4 @@
+export spack_stack_ver=1.9.1
 export stack_oneapi_ver=2024.2.1
 export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"

--- a/versions/run.hera.ver
+++ b/versions/run.hera.ver
@@ -1,6 +1,6 @@
-export spack_stack_ver=1.9.1
 export stack_oneapi_ver=2024.2.1
 export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"
+export spack_stack_ver=1.9.1
 export cmake_ver=3.27.9
 export spack_stack_mod_path="/contrib/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"

--- a/versions/spack.ver
+++ b/versions/spack.ver
@@ -1,4 +1,4 @@
-export spack_stack_ver=1.9.1
+export spack_stack_ver=1.9.2
 export spack_env=ue-oneapi-2024.2.1
 
 export cmake_ver=3.30.2

--- a/versions/spack.ver
+++ b/versions/spack.ver
@@ -1,7 +1,7 @@
 export spack_stack_ver=1.9.2
 export spack_env=ue-oneapi-2024.2.1
 
-export cmake_ver=3.30.2
+export cmake_ver=3.27.9
 
 export jasper_ver=2.0.32
 export libpng_ver=1.6.37


### PR DESCRIPTION
Update to use `spack-stack/1.9.2` on R&Ds but keep Hera using `spack-stack/1.9.1`. Also:

1. add unload of `cray-libsci` to Gaea C6 build (needed after recent maintenance)
2. change `cmake` version to `3.27.9` to use the stack version

Resolves #48 

Will recut and reinstall `prepobs.v1.1.1-rd-gfsv17` tag after this PR goes in.