### PR TITLE
Update cloud environments to use spack-stack 1.9.2

### DIFF
--- a/modulefiles/prepobs_noaacloud.lua
+++ b/modulefiles/prepobs_noaacloud.lua
@@ -3,17 +3,24 @@ Load environment to build prepobs on NOAA cloud
 ]])
 
 prepend_path("MODULEPATH", os.getenv("spack_stack_mod_path"))
+prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
-stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
-stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+gnu_ver=os.getenv("gnu_ver") or "13.2.0"
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+mkl_ver=os.getenv("mkl_ver") or "2024.2.1"
 
-load("gnu")
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+load(pathJoin("gnu", gnu_ver))
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
 load(pathJoin("cmake", cmake_ver))
+load(pathJoin("mkl", mkl_ver))
 
 -- Load common modules for this package
 load("prepobs_common")
+
+--setenv("MKL_LIBRARIES", "/apps/oneapi/mkl/2024.2/lib")
+--setenv("MKL_INCLUDE_DIRS", "/apps/oneapi/mkl/2024.2/include")
 
 whatis("Description: prepobs build environment")

--- a/modulefiles/prepobs_noaacloud.lua
+++ b/modulefiles/prepobs_noaacloud.lua
@@ -20,7 +20,4 @@ load(pathJoin("mkl", mkl_ver))
 -- Load common modules for this package
 load("prepobs_common")
 
---setenv("MKL_LIBRARIES", "/apps/oneapi/mkl/2024.2/lib")
---setenv("MKL_INCLUDE_DIRS", "/apps/oneapi/mkl/2024.2/include")
-
 whatis("Description: prepobs build environment")

--- a/versions/build.noaacloud.ver
+++ b/versions/build.noaacloud.ver
@@ -1,4 +1,5 @@
-export stack_intel_ver=2021.10.0
-export stack_impi_ver=2021.10.0
+export gnu_ver=13.2.0
+export stack_oneapi_ver=2024.2.1
+export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"
-export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-${spack_stack_ver}/envs/${spack_env}-env/install/modulefiles/Core"
+export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"

--- a/versions/run.noaacloud.ver
+++ b/versions/run.noaacloud.ver
@@ -1,4 +1,5 @@
-export stack_intel_ver=2021.10.0
-export stack_impi_ver=2021.10.0
+export gnu_ver=13.2.0
+export stack_oneapi_ver=2024.2.1
+export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"
-export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-${spack_stack_ver}/envs/${spack_env}-env/install/modulefiles/Core"
+export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"


### PR DESCRIPTION
This PR edits the cloud module file and build/run version files for using spack-stack 1.9.2. It also adds loading `mkl` in the cloud module file since this available in the NOAA RDHPCS /apps snapshot available on the cloud. 

Resolves #50 