### PR TITLE
Rename prep job inputs

### DIFF
--- a/modulefiles/prepobs_hera.lua
+++ b/modulefiles/prepobs_hera.lua
@@ -6,7 +6,7 @@ prepend_path("MODULEPATH", os.getenv("spack_stack_mod_path"))
 
 stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
-cmake_ver=os.getenv("cmake_ver") or "3.30.2"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))

--- a/ush/getges_nc.sh
+++ b/ush/getges_nc.sh
@@ -446,7 +446,7 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
    $COMINcfs_cdas/cdas1.t${cyc}z.bf$fhp3'
    ;;
   biascr) geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.abias.txt'
+   $COMINcfs_cdas/cdas1.t${cyc}z.abias'
    ;;
   satang) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.satang'
@@ -460,10 +460,10 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
    fhend=00
    ;;
   sfgges)  geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sflux.f$fh.grib2'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf.f$fh'
    ;;
   sfggp3)  geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sflux.f$fhp3.grib2'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf.f$fhp3'
    ;;
   pgbges) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.pgrbh$fh 
@@ -506,7 +506,7 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
   sfccur) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.bf$fh'
    getlist00='
-   $COMINcfs_cdas/cdas1.t${cyc}z.anl.sfc'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sfcanl'
    fhbeg=00
    ;;
   pgbcur) geslist='
@@ -712,7 +712,7 @@ elif [[ "$netwk" = "cdas" ]];then
    $COMINcdas/cdas.t${cyc}z.bf$fhp3'
    ;;
   biascr) geslist='
-   $COMINcdas/cdas.t${cyc}z.abias.txt'
+   $COMINcdas/cdas.t${cyc}z.abias'
    ;;
   satang) geslist='
    $COMINcdas/cdas.t${cyc}z.satang'
@@ -758,7 +758,7 @@ elif [[ "$netwk" = "cdas" ]];then
   sfccur) geslist='
    $COMINcdas/cdas.t${cyc}z.bf$fh'
    getlist00='
-   $COMINcdas/cdas.t${cyc}z.anl.sfc'
+   $COMINcdas/cdas.t${cyc}z.sfcanl'
    fhbeg=00
    ;;
   pgbcur) geslist='
@@ -873,7 +873,7 @@ elif [[ "$netwk" = "cdc" ]];then
    $COMINcdc/cdas.t${cyc}z.bf$fhp3'
    ;;
   biascr) geslist='
-   $COMINcdc/cdas.t${cyc}z.abias.txt'
+   $COMINcdc/cdas.t${cyc}z.abias'
    ;;
   satang) geslist='
    $COMINcdc/cdas.t${cyc}z.satang'
@@ -919,7 +919,7 @@ elif [[ "$netwk" = "cdc" ]];then
   sfccur) geslist='
    $COMINcdc/cdas.t${cyc}z.bf$fh'
    getlist00='
-   $COMINcdc/cdas.t${cyc}z.anl.sfc'
+   $COMINcdc/cdas.t${cyc}z.sfcanl'
    fhbeg=00
    ;;
   pgbcur) geslist='
@@ -1392,8 +1392,8 @@ while [[ $fh -le $fhend ]];do
      [[ $cyc -ne $bn ]]  && break 1
   fi
   gesbn=`basename $ges`
-  logfbn=${gesbn/atm/atm.log}
-  logfbn=$(echo ${logfbn/nc/txt})
+  logfbn=${gesbn/atm/log}
+  logfbn=${logfbn/nc/txt}
   logf=$dn/$logfbn
   if [[ $quiet = NO ]]; then
     echo Checking: $logf >&2

--- a/ush/getges_nc.sh
+++ b/ush/getges_nc.sh
@@ -460,10 +460,10 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
    fhend=00
    ;;
   sfgges)  geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf$fh'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sflux.f$fh.grib2'
    ;;
   sfggp3)  geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf$fhp3'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sflux.f$fhp3.grib2'
    ;;
   pgbges) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.pgrbh$fh 

--- a/ush/getges_nc.sh
+++ b/ush/getges_nc.sh
@@ -460,10 +460,10 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
    fhend=00
    ;;
   sfgges)  geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf.f$fh'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf$fh'
    ;;
   sfggp3)  geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf.f$fhp3'
+   $COMINcfs_cdas/cdas1.t${cyc}z.sfluxgrbf$fhp3'
    ;;
   pgbges) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.pgrbh$fh 

--- a/ush/getges_nc.sh
+++ b/ush/getges_nc.sh
@@ -232,23 +232,23 @@ if [[ "$netwk" = "gdas" ]];then
  fhend=12
  case $typef in
   biascr) geslist='
-   $COMINgdas/gdas.t${cyc}z.abias'
+   $COMINgdas/gdas.t${cyc}z.abias.txt'
    ;;
   biascr_pc) geslist='
-   $COMINgdas/gdas.t${cyc}z.abias_pc'
+   $COMINgdas/gdas.t${cyc}z.abias_pc.txt'
    ;;
   biascr_air) geslist='
-   $COMINgdas/gdas.t${cyc}z.abias_air'
+   $COMINgdas/gdas.t${cyc}z.abias_air.txt'
    ;;
   radstat) geslist='
-   $COMINgdas/gdas.t${cyc}z.radstat'
+   $COMINgdas/gdas.t${cyc}z.radstat.tar'
    ;;
   pgbges) geslist='
    $COMINgdas/gdas.t${cyc}z.pgrbh$fh 
    $COMINgdas/gdas.t${cyc}z.pgrbf$fh'
    ;;
   pg2ges) geslist='
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$gh'
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$gh.grib2'
    ;;
   pgbgm6) geslist='
    $COMINgdas/gdas.t${cyc}z.pgrbh$fhm6 
@@ -268,7 +268,7 @@ if [[ "$netwk" = "gdas" ]];then
    fhbeg=00
    ;;
   pg2cur) geslist='
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$gh'
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$gh.grib2'
    fhbeg=00
    ;;
   prepqc) geslist='
@@ -317,57 +317,57 @@ if [[ "$netwk" = "gdas" ]];then
    fhinc=06
    ;;
   natges) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$gh.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$gh.nc'
    ;;
   natgm3) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghm3.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghm3.nc'
    ;;
   natgm2) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghm2.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghm2.nc'
    ;;
   natgm1) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghm1.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghm1.nc'
    ;;
   natgp1) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghp1.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghp1.nc'
    ;;
   natgp2) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghp2.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghp2.nc'
    ;;
   natgp3) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghp3.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghp3.nc'
    ;;
   natcur) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$gh.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$gh.nc'
    getlist00='
-   $COMINgdas/gdas.t${cyc}z.atmanl.nc'
+   $COMINgdas/gdas.t${cyc}z.anl.atm.nc'
    fhbeg=00
    ;;
   nsfges) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$gh.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$gh.nc'
    ;;
   nsfgm3) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghm3.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghm3.nc'
    ;;
   nsfgm2) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghm2.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghm2.nc'
    ;;
   nsfgm1) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghm1.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghm1.nc'
    ;;
   nsfgp1) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghp1.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghp1.nc'
    ;;
   nsfgp2) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghp2.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghp2.nc'
    ;;
   nsfgp3) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghp3.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghp3.nc'
    ;;
   nsfcur) geslist='
-   $COMINgdas/gdas.t${cyc}z.sfcf$gh.nc'
+   $COMINgdas/gdas.t${cyc}z.sfc.f$gh.nc'
    getlist00='
-   $COMINgdas/gdas.t${cyc}z.sfcanl.nc'
+   $COMINgdas/gdas.t${cyc}z.anl.sfc.nc'
    fhbeg=00
    ;;
   nstcur) geslist='
@@ -446,7 +446,7 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
    $COMINcfs_cdas/cdas1.t${cyc}z.bf$fhp3'
    ;;
   biascr) geslist='
-   $COMINcfs_cdas/cdas1.t${cyc}z.abias'
+   $COMINcfs_cdas/cdas1.t${cyc}z.abias.txt'
    ;;
   satang) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.satang'
@@ -506,7 +506,7 @@ elif [[ "$netwk" = "cfs-cdas" ]];then
   sfccur) geslist='
    $COMINcfs_cdas/cdas1.t${cyc}z.bf$fh'
    getlist00='
-   $COMINcfs_cdas/cdas1.t${cyc}z.sfcanl'
+   $COMINcfs_cdas/cdas1.t${cyc}z.anl.sfc'
    fhbeg=00
    ;;
   pgbcur) geslist='
@@ -596,14 +596,14 @@ elif [[ "$netwk" = "gfs" ]];then
  fhend=384
  case $typef in
   natges) geslist='
-   $COMINgfs/gfs.t${cyc}z.atmf$gh.nc'
+   $COMINgfs/gfs.t${cyc}z.atm.f$gh.nc'
    ;;
   pgbcur) geslist='
    $COMINgfs/gfs.t${cyc}z.pgrbf$fh'
    fhbeg=00
    ;;
   pg2cur) geslist='
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$gh'
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$gh.grib2'
    fhbeg=00
    ;;
   prepqc) geslist='
@@ -637,15 +637,15 @@ elif [[ "$netwk" = "gfs" ]];then
    fhinc=06
    ;;
   natcur) geslist='
-   $COMINgfs/gfs.t${cyc}z.atmf$gh.nc'
+   $COMINgfs/gfs.t${cyc}z.atm.f$gh.nc'
    getlist00='
-   $COMINgfs/gfs.t${cyc}z.atmanl.nc'
+   $COMINgfs/gfs.t${cyc}z.anl.atm.nc'
    fhbeg=00
    ;;
   nsfcur) geslist='
-   $COMINgfs/gfs.t${cyc}z.sfcf$gh.nc'
+   $COMINgfs/gfs.t${cyc}z.sfc.f$gh.nc'
    getlist00='
-   $COMINgfs/gfs.t${cyc}z.sfcanl.nc'
+   $COMINgfs/gfs.t${cyc}z.anl.sfc.nc'
    fhbeg=00
    ;;
   nstcur) geslist='
@@ -712,7 +712,7 @@ elif [[ "$netwk" = "cdas" ]];then
    $COMINcdas/cdas.t${cyc}z.bf$fhp3'
    ;;
   biascr) geslist='
-   $COMINcdas/cdas.t${cyc}z.abias'
+   $COMINcdas/cdas.t${cyc}z.abias.txt'
    ;;
   satang) geslist='
    $COMINcdas/cdas.t${cyc}z.satang'
@@ -758,7 +758,7 @@ elif [[ "$netwk" = "cdas" ]];then
   sfccur) geslist='
    $COMINcdas/cdas.t${cyc}z.bf$fh'
    getlist00='
-   $COMINcdas/cdas.t${cyc}z.sfcanl'
+   $COMINcdas/cdas.t${cyc}z.anl.sfc'
    fhbeg=00
    ;;
   pgbcur) geslist='
@@ -873,7 +873,7 @@ elif [[ "$netwk" = "cdc" ]];then
    $COMINcdc/cdas.t${cyc}z.bf$fhp3'
    ;;
   biascr) geslist='
-   $COMINcdc/cdas.t${cyc}z.abias'
+   $COMINcdc/cdas.t${cyc}z.abias.txt'
    ;;
   satang) geslist='
    $COMINcdc/cdas.t${cyc}z.satang'
@@ -919,7 +919,7 @@ elif [[ "$netwk" = "cdc" ]];then
   sfccur) geslist='
    $COMINcdc/cdas.t${cyc}z.bf$fh'
    getlist00='
-   $COMINcdc/cdas.t${cyc}z.sfcanl'
+   $COMINcdc/cdas.t${cyc}z.anl.sfc'
    fhbeg=00
    ;;
   pgbcur) geslist='
@@ -995,10 +995,10 @@ elif [[ "$netwk" = "global" ]];then
  GETGES_NWG=${GETGES_NWG:-${COMROOT:?}/nwges}
  case $typef in
   biascr) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.abias
-   $COMINgdas/gdas.t${cyc}z.abias
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.abias
-   $COMINgfs/gfs.t${cyc}z.abias'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.abias.txt
+   $COMINgdas/gdas.t${cyc}z.abias.txt
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.abias.txt
+   $COMINgfs/gfs.t${cyc}z.abias.txt'
    fhbeg=06
    fhinc=06
    ;;
@@ -1035,64 +1035,64 @@ elif [[ "$netwk" = "global" ]];then
    $COMINgfs/gfs.t${cyc}z.pgrbf$fhp3'
    ;;
   pg2ges) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$gh
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$gh
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$gh
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$gh'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$gh.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$gh.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$gh.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$gh.grib2'
    ;;
   pg2gm6) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghm6
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghm6
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghm6
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghm6'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghm6.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghm6.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghm6.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghm6.grib2'
    ;;
   pg2gm5) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghm5
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghm5
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghm5
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghm5'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghm5.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghm5.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghm5.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghm5.grib2'
    ;;
   pg2gm4) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghm4
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghm4
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghm4
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghm4'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghm4.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghm4.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghm4.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghm4.grib2'
    ;;
   pg2gm3) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghm3
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghm3
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghm3
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghm3'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghm3.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghm3.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghm3.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghm3.grib2'
    ;;
   pg2gm2) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghm2
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghm2
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghm2
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghm2'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghm2.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghm2.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghm2.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghm2.grib2'
    ;;
   pg2gm1) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghm1
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghm1
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghm1
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghm1'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghm1.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghm1.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghm1.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghm1.grib2'
    ;;
   pg2gp1) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghp1
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghp1
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghp1
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghp1'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghp1.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghp1.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghp1.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghp1.grib2'
    ;;
   pg2gp2) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghp2
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghp2
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghp2
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghp2'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghp2.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghp2.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghp2.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghp2.grib2'
    ;;
   pg2gp3) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p25.f$ghp3
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p25.f$ghp3
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p25.f$ghp3
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p25.f$ghp3'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p25.f$ghp3.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p25.f$ghp3.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p25.f$ghp3.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p25.f$ghp3.grib2'
    ;;
   pgbcur) geslist='
    $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrbh$fh
@@ -1104,10 +1104,10 @@ elif [[ "$netwk" = "global" ]];then
    fhbeg=00
    ;;
   pg2cur) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pgrb2.0p50.f$gh
-   $COMINgdas/gdas.t${cyc}z.pgrb2.0p50.f$gh
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pgrb2.0p50.f$gh
-   $COMINgfs/gfs.t${cyc}z.pgrb2.0p50.f$gh'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.pres_a.0p50.f$gh.grib2
+   $COMINgdas/gdas.t${cyc}z.pres_a.0p50.f$gh.grib2
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.pres_a.0p50.f$gh.grib2
+   $COMINgfs/gfs.t${cyc}z.pres_a.0p50.f$gh.grib2'
    fhbeg=00
    ;;
   prepqc) geslist='
@@ -1183,109 +1183,109 @@ elif [[ "$netwk" = "global" ]];then
    fhinc=06
    ;;
   natges) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$gh.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$gh.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$gh.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$gh.nc'
    ((vhr=$valid%100))
    if [[ $(($vhr % 3)) -ne 0 ]]; then
       fhinc=01
    fi
    ;;
   natgm3) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghm3.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$ghm3.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghm3.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$ghm3.nc'
    ;;
   natgm2) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atmf$ghm2.nc
-   $COMINgdas/gdas.t${cyc}z.atmf$ghm2.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atmf$ghm2.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$ghm2.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atm.f$ghm2.nc
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghm2.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atm.f$ghm2.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$ghm2.nc'
    ;;
   natgm1) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atmf$ghm1.nc
-   $COMINgdas/gdas.t${cyc}z.atmf$ghm1.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atmf$ghm1.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$ghm1.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atm.f$ghm1.nc
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghm1.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atm.f$ghm1.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$ghm1.nc'
    ;;
   natgp1) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atmf$ghp1.nc
-   $COMINgdas/gdas.t${cyc}z.atmf$ghp1.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atmf$ghp1.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$ghp1.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atm.f$ghp1.nc
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghp1.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atm.f$ghp1.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$ghp1.nc'
    ;;
   natgp2) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atmf$ghp2.nc
-   $COMINgdas/gdas.t${cyc}z.atmf$ghp2.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atmf$ghp2.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$ghp2.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atm.f$ghp2.nc
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghp2.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atm.f$ghp2.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$ghp2.nc'
    ;;
   natgp3) geslist='
-   $COMINgdas/gdas.t${cyc}z.atmf$ghp3.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$ghp3.nc'
+   $COMINgdas/gdas.t${cyc}z.atm.f$ghp3.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$ghp3.nc'
    ;;
   natcur) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atmf$gh.nc
-   $COMINgdas/gdas.t${cyc}z.atmf$gh.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atmf$gh.nc
-   $COMINgfs/gfs.t${cyc}z.atmf$gh.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atm.f$gh.nc
+   $COMINgdas/gdas.t${cyc}z.atm.f$gh.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atm.f$gh.nc
+   $COMINgfs/gfs.t${cyc}z.atm.f$gh.nc'
    getlist00='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.atmanl.nc
-   $COMINgdas/gdas.t${cyc}z.atmanl.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.atmanl.nc
-   $COMINgfs/gfs.t${cyc}z.atmanl.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.anl.atm.nc
+   $COMINgdas/gdas.t${cyc}z.anl.atm.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.anl.atm.nc
+   $COMINgfs/gfs.t${cyc}z.anl.atm.nc'
    fhbeg=00
    ;;
   nsfges) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$gh.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$gh.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$gh.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$gh.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$gh.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$gh.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$gh.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$gh.nc'
    ;;
   nsfgm3) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$ghm3.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghm3.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$ghm3.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$ghm3.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$ghm3.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghm3.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$ghm3.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$ghm3.nc'
    ;;
   nsfgm2) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$ghm2.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghm2.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$ghm2.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$ghm2.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$ghm2.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghm2.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$ghm2.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$ghm2.nc'
    ;;
   nsfgm1) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$ghm1.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghm1.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$ghm1.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$ghm1.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$ghm1.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghm1.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$ghm1.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$ghm1.nc'
    ;;
   nsfgp1) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$ghp1.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghp1.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$ghp1.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$ghp1.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$ghp1.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghp1.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$ghp1.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$ghp1.nc'
    ;;
   nsfgp2) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$ghp2.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghp2.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$ghp2.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$ghp2.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$ghp2.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghp2.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$ghp2.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$ghp2.nc'
    ;;
   nsfgp3) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$ghp3.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$ghp3.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$ghp3.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$ghp3.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$ghp3.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$ghp3.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$ghp3.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$ghp3.nc'
    ;;
   nsfcur) geslist='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcf$gh.nc
-   $COMINgdas/gdas.t${cyc}z.sfcf$gh.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcf$gh.nc
-   $COMINgfs/gfs.t${cyc}z.sfcf$gh.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfc.f$gh.nc
+   $COMINgdas/gdas.t${cyc}z.sfc.f$gh.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfc.f$gh.nc
+   $COMINgfs/gfs.t${cyc}z.sfc.f$gh.nc'
    getlist00='
-   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.sfcanl.nc
-   $COMINgdas/gdas.t${cyc}z.sfcanl.nc
-   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.sfcanl.nc
-   $COMINgfs/gfs.t${cyc}z.sfcanl.nc'
+   $GETGES_NWG/$envir/gdas.$day/gdas.t${cyc}z.anl.sfc.nc
+   $COMINgdas/gdas.t${cyc}z.anl.sfc.nc
+   $GETGES_NWG/$envir/gfs.$day/gfs.t${cyc}z.anl.sfc.nc
+   $COMINgfs/gfs.t${cyc}z.anl.sfc.nc'
    fhbeg=00
    ;;
   nstcur) geslist='

--- a/versions/build.hera.ver
+++ b/versions/build.hera.ver
@@ -1,6 +1,6 @@
 export stack_oneapi_ver=2024.2.1
 export stack_intel_oneapi_mpi_ver=2021.13
 source "${HOMEprepobs:-}/versions/spack.ver"
-export spack_stack_ver=1.9.1
+export spack_stack_ver=1.9.2
 export cmake_ver=3.27.9
 export spack_stack_mod_path="/contrib/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"


### PR DESCRIPTION
This PR is connected to the global workflow issue https://github.com/NOAA-EMC/global-workflow/issues/3271.  This renames the input `atm`, `sfc` and `grib2` files to the expected formats.